### PR TITLE
add js tooltip fallback for safari

### DIFF
--- a/products.css
+++ b/products.css
@@ -2174,7 +2174,12 @@ html {
     top: 0
 }
 
-.with-tooltip:hover .tooltip,.with-tooltip:hover:after,.with-tooltip:hover:focus .tooltip,.with-tooltip:hover:focus:after {
+.with-tooltip:hover .tooltip,
+.with-tooltip:hover:after,
+.with-tooltip:hover:focus .tooltip,
+.with-tooltip:hover:focus:after,
+.with-tooltip.has-focus .tooltip,
+.with-tooltip.has-focus:after{
     opacity: 1;
     pointer-events: auto
 }

--- a/products.js
+++ b/products.js
@@ -110,6 +110,17 @@ $(document).ready(() => {
         $('.mockup-button.selected').removeClass('selected');
         $('.mockup-button').eq(newIndex).addClass('selected');
     });
+
+    // Add JS fallback for safari because it doesn't implement :focus properly
+    $('.with-tooltip').click(e => {
+        $(e.target)
+            .closest('.with-tooltip')
+                .toggleClass('has-focus');
+    })
+    // when anything else is tapped/clicked, remove the faux-focus class
+    $('*:not(.with-tooltip):not(.tooltip)').click(e => {
+        $('.with-tooltip').removeClass('has-focus');
+    })
 })
 
 /*jQuery extensions*/


### PR DESCRIPTION
Apparently iOS doesn't implement :focus correctly (or at all), so add some Javascript fallback to handle taps on elements with tooltips